### PR TITLE
BVGraph: load OBL offsets even if they have a later modification time

### DIFF
--- a/src/it/unimi/dsi/webgraph/BVGraph.java
+++ b/src/it/unimi/dsi/webgraph/BVGraph.java
@@ -273,7 +273,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * process, in particular with large graphs. The main method of this class
  * has an option that will generate such a list once for all and serialise it in a file with
  * extension <code>.obl</code>. The list will be quickly deserialised
- * if its modification date is later than that of the offset file.
+ * if this file is present.
  *
  * <H2>Not Loading the Graph File at All</H2>
  *
@@ -1496,8 +1496,7 @@ public class BVGraph extends ImmutableGraph implements CompressionFlags, Seriali
 
 			// We try to load a cached big list.
 			final File offsetsBigListFile = new File(basename + OFFSETS_BIG_LIST_EXTENSION);
-			if (offsetsBigListFile.exists()) if (new File(basename + OFFSETS_EXTENSION).lastModified() > offsetsBigListFile.lastModified()) LOGGER.warn("A cached long big list of offsets was found, but the corresponding offsets file has a later modification time");
-			else try {
+			try {
 				offsets = (LongBigList)BinIO.loadObject(offsetsBigListFile);
 			}
 			catch (final ClassNotFoundException e) {


### PR DESCRIPTION
**Pull-request for webgraph-big here: https://github.com/vigna/webgraph-big/pull/6**


Before this commit, BVGraph checked whether the OBL cache file was more
recent than the offsets file it was caching, to ensure that the cache
file was still valid.

However, file modification times are not a reliable way to check this.
When we copy the compressed graph from a remote server, the .obl file
will often be written first because it goes before .offsets in the
lexicographic order, and will then have an earlier ctime/mtime. We
therefore need to systematically touch(1) the .obl files after a copy.

I would argue that these checks should be done externally, and it makes little
sense to do them from within WebGraph, just like we should not check whether
other "derived files" have a later mtime than the files that were used to
generate them.